### PR TITLE
Set compat bounds for CImGui

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-CImGui = "1.82.0"
+CImGui = "~1.82"
 ColorTypes = "0.11"
 Configurations = "0.17"
 FileIO = "1"


### PR DESCRIPTION
CImGui major/minor versions follow upstream ImGui, so minor version updates may be breaking. This only allows patch updates.

(making the PR because there's a new breaking release: https://github.com/Gnimuc/CImGui.jl/releases/tag/v1.89.0)